### PR TITLE
Add reckon plugin

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,4 +30,17 @@ dependencyResolutionManagement {
     }
 }
 
+plugins {
+    id("org.ajoberstar.reckon.settings") version "0.19.2"
+}
+
+extensions.configure<org.ajoberstar.reckon.gradle.ReckonExtension> {
+    setDefaultInferredScope("patch")
+    stages("beta", "rc", "final")
+    setScopeCalc(calcScopeFromProp().or(calcScopeFromCommitMessages()))
+    setStageCalc(calcStageFromProp())
+}
+
+
+
 include(":composeApp")


### PR DESCRIPTION
This pull request adds automated versioning configuration to the project's Gradle settings by introducing the Reckon plugin. The change sets up version inference based on commit messages and properties, and defines the release stages.

Versioning automation:

* Added the `org.ajoberstar.reckon.settings` plugin (version 0.19.2) to `settings.gradle.kts` for automated semantic versioning.
* Configured the Reckon extension to:
  * Default the inferred scope to "patch"
  * Define release stages as "beta", "rc", and "final"
  * Infer scope from project properties or commit messages
  * Infer stage from project properties