### PR TITLE
Add printVersion Gradle task

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -101,4 +101,11 @@ buildkonfig {
     }
 }
 
+tasks.register("printVersion") {
+    doLast {
+        println("${project.version}")
+    }
+}
+
+
 


### PR DESCRIPTION
This pull request introduces a new Gradle task to the `composeApp/build.gradle.kts` file that enables printing the current project version from the command line.

Build tooling improvement:

* Added a `printVersion` Gradle task that outputs the current project version when run, making it easier to check the version from the CLI.