### PR TITLE
Refactor release workflow to support workflow calls and add GITHUB_TO…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,10 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_call:
+    secrets:
+        GITHUB_TOKEN:
+            required: true
 
 jobs:
   build:

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -52,3 +52,8 @@ jobs:
           git config user.email "actions@github.com"
           git tag "v${{ steps.reckon.outputs.version }}"
           git push origin "v${{ steps.reckon.outputs.version }}"
+
+      - name: Create Release
+        uses: Home-One-Tactical-Headquarters/HoloNet/.github/workflows/release.yml@main
+        secrets:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the release automation by changing how the release workflow is triggered and integrating it into the version bump process. The main improvements are focused on workflow orchestration and automation.

**Workflow orchestration improvements:**

* Changed `.github/workflows/release.yml` to be triggered via `workflow_call` instead of on tag push, and required the `GITHUB_TOKEN` secret for invocation.

**Automation integration:**

* Updated `.github/workflows/version-bump.yml` to call the `release.yml` workflow after tagging a new version, passing the required `GITHUB_TOKEN` secret.