### PR TITLE
Fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   workflow_call:
     secrets:
-        GITHUB_TOKEN:
+        token:
             required: true
 
 jobs:
@@ -50,4 +50,4 @@ jobs:
           generate_release_notes: true
           files: dist/**/*
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.token }}

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -53,7 +53,7 @@ jobs:
           git tag "v${{ steps.reckon.outputs.version }}"
           git push origin "v${{ steps.reckon.outputs.version }}"
 
-      - name: Create Release
-        uses: Home-One-Tactical-Headquarters/HoloNet/.github/workflows/release.yml@main
-        secrets:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  release:
+    uses: Home-One-Tactical-Headquarters/HoloNet/.github/workflows/release.yml@main
+    secrets:
+        token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates how secrets are referenced and passed between GitHub Actions workflows, specifically standardizing the use of the `token` secret instead of `GITHUB_TOKEN`. This change ensures consistency and proper secret handling across workflow calls and jobs.

**GitHub Actions workflow updates:**

* Changed the required secret from `GITHUB_TOKEN` to `token` in the `workflow_call` definition of `.github/workflows/release.yml` to standardize secret naming.
* Updated references within `.github/workflows/release.yml` to use `secrets.token` instead of `secrets.GITHUB_TOKEN` when setting the `GITHUB_TOKEN` environment variable for jobs.
* Modified `.github/workflows/version-bump.yml` to pass the `GITHUB_TOKEN` as `token` when invoking the `release.yml` workflow, aligning with the new secret naming convention.