### PR TITLE
Fix branch detection and wait for version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Exit if not on master branch
-        if: endsWith(github.ref, 'master') == false
+      - name: Exit if not on main branch
+        if: endsWith(github.ref, 'main') == false
         run: exit -1
 
       - uses: actions/setup-java@v4

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -54,6 +54,7 @@ jobs:
           git push origin "v${{ steps.reckon.outputs.version }}"
 
   release:
+    needs: version
     uses: Home-One-Tactical-Headquarters/HoloNet/.github/workflows/release.yml@main
     secrets:
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to align with the current default branch naming and improve workflow dependencies. The main changes are related to branch checks and workflow chaining.

Branch and workflow updates:

* Updated the branch check in `.github/workflows/release.yml` to exit if the workflow is not running on the `main` branch instead of `master`.
* Added a dependency in `.github/workflows/version-bump.yml` so that the `release` job waits for the `version` job to complete before running, ensuring correct workflow execution order.